### PR TITLE
#7 : Change hashing methodology, add a test to ensure stability

### DIFF
--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReportGenerator.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReportGenerator.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Multimap;
+import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
@@ -146,13 +147,10 @@ public class ReportGenerator {
                 .append(':').append(method.getOutput().trim())
                 .toString();
 
-        String sha256hex = Hashing.sha256()
-                .hashString(signature, StandardCharsets.UTF_8)
-                .toString();
+        HashCode sha256 = Hashing.sha256()
+                .hashString(signature, StandardCharsets.UTF_8);
 
-        byte[] encoded = Base64.getEncoder().encode(sha256hex.getBytes(StandardCharsets.UTF_8));
-
-        return new String(encoded, StandardCharsets.UTF_8);
+        return Base64.getEncoder().encodeToString(sha256.asBytes());
     }
 
     /**

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
@@ -117,6 +117,8 @@ public class ReportGeneratorTest {
         ReferencedMethodUsesJson resultJson = usesById.values().stream().findFirst().get();
 
         Assert.assertEquals(usesById.size(), 1);
+        Assert.assertEquals(resultJson.getMethod().getId(), "n0VJzGLYjELWet+V5A3IxQgkG/kQRR3P0OTmEpiScZs=",
+                "Referenced Method ID was unexpected value, check that ID generation logic in ReportGenerator was not changed unintentionally.");
         Assert.assertEquals(resultJson.getMethod().getMethodName(), "methodName");
         Assert.assertEquals(resultJson.getMethod().getMethodOwner(), "methodOwner");
         Assert.assertEquals(resultJson.getMethod().getOutput(), "output");


### PR DESCRIPTION
Changed the hashing methodology to the one @mydimension suggested in the issue.

However in the issue he added examples of hashing the string "foo" on the CLI via hexstring and bytes, and I tried to reproduce that via the Java code we're using and none of my results matched with either of his. Not sure if there's something else there I'm not understanding. Worth discussing before this gets merged.