### PR TITLE
Store Method User and Line Number Separately

### DIFF
--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/MethodUseAnalyzer.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/MethodUseAnalyzer.java
@@ -39,6 +39,7 @@ import org.objectweb.asm.ClassReader;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Multimap;
 import com.synopsys.method.analyzer.core.bytecode.ClassMethodReferenceVisitor;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 import com.synopsys.method.analyzer.core.report.ReportGenerator;
 
@@ -104,7 +105,7 @@ public class MethodUseAnalyzer {
         Preconditions.checkArgument(Files.exists(sourceDirectory), "The source path provided (%s) does not exist", sourceDirectory.toString());
         Preconditions.checkArgument(Files.isDirectory(sourceDirectory), "The source path provided (%s) is not a directory", sourceDirectory.toString());
 
-        Multimap<ReferencedMethod, String> references = null;
+        Multimap<ReferencedMethod, MethodUse> references = null;
         ReportGenerator reportGenerator = new ReportGenerator(InetAddress.getLocalHost().getHostName(), sourceDirectory.toString(), projectName);
 
         try (Stream<Path> files = Files.walk(sourceDirectory)) {

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/ClassMethodReferenceVisitor.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/ClassMethodReferenceVisitor.java
@@ -38,6 +38,7 @@ import org.objectweb.asm.Opcodes;
 import org.objectweb.asm.Type;
 
 import com.google.common.collect.Multimap;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 
 /**
@@ -95,7 +96,7 @@ public class ClassMethodReferenceVisitor extends ClassVisitor {
     /**
      * @return A mapping of external method references to one or more use locations
      */
-    public Multimap<ReferencedMethod, String> getReferences() {
+    public Multimap<ReferencedMethod, MethodUse> getReferences() {
         return referenceRegistry.getReferences();
     }
 

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/ClassMethodReferenceVisitor.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/ClassMethodReferenceVisitor.java
@@ -200,9 +200,9 @@ public class ClassMethodReferenceVisitor extends ClassVisitor {
                     .map(Type::getClassName)
                     .collect(Collectors.toList());
 
-            String useReference = currentClassName + "." + currentMethodName + ":" + (currentLine != null ? currentLine : "?");
+            String useReference = currentClassName + "." + currentMethodName;
 
-            referenceRegistry.registerReference(formatQualifiedName(effectiveOwner), name, argumentList, returnType.getClassName(), useReference);
+            referenceRegistry.registerReference(formatQualifiedName(effectiveOwner), name, argumentList, returnType.getClassName(), useReference, currentLine);
         }
 
     }

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/MethodReferenceRegistry.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/MethodReferenceRegistry.java
@@ -36,6 +36,7 @@ import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.common.collect.Table;
 import com.google.common.collect.Table.Cell;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 
 /**
@@ -50,7 +51,7 @@ import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 public class MethodReferenceRegistry {
 
     // Key'd by owner, signature, value of referenced locations
-    private final Table<String, ReferencedMethod, Collection<String>> references;
+    private final Table<String, ReferencedMethod, Collection<MethodUse>> references;
 
     private final Set<String> methodOwnerExclusions;
 
@@ -83,11 +84,11 @@ public class MethodReferenceRegistry {
         Objects.requireNonNull(whereUsed);
 
         if (!methodOwnerExclusions.contains(methodOwner)) {
-            String useReference = whereUsed + ":" + (lineNumber != null ? lineNumber : "?");
+            MethodUse useReference = new MethodUse(whereUsed, lineNumber);
 
             ReferencedMethod referencedMethod = new ReferencedMethod(methodOwner, methodName, inputs, output);
 
-            Collection<String> values = Optional.ofNullable(references.get(methodOwner, referencedMethod))
+            Collection<MethodUse> values = Optional.ofNullable(references.get(methodOwner, referencedMethod))
                     .orElse(new HashSet<>());
             values.add(useReference);
 
@@ -115,10 +116,10 @@ public class MethodReferenceRegistry {
     /**
      * @return A mapping of referenced methods to one or more locations use was detected in
      */
-    public Multimap<ReferencedMethod, String> getReferences() {
-        Multimap<ReferencedMethod, String> result = HashMultimap.create();
+    public Multimap<ReferencedMethod, MethodUse> getReferences() {
+        Multimap<ReferencedMethod, MethodUse> result = HashMultimap.create();
 
-        for (Cell<String, ReferencedMethod, Collection<String>> reference : references.cellSet()) {
+        for (Cell<String, ReferencedMethod, Collection<MethodUse>> reference : references.cellSet()) {
             result.putAll(reference.getColumnKey(), reference.getValue());
         }
 

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/MethodReferenceRegistry.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/bytecode/MethodReferenceRegistry.java
@@ -29,6 +29,8 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 
+import javax.annotation.Nullable;
+
 import com.google.common.collect.HashBasedTable;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -70,8 +72,10 @@ public class MethodReferenceRegistry {
      *            The class the method returns, or "void"
      * @param whereUsed
      *            A signature of where within the analyzed project the method was referenced
+     * @param lineNumber
+     *            If available, the line the method was referenced on
      */
-    public void registerReference(String methodOwner, String methodName, List<String> inputs, String output, String whereUsed) {
+    public void registerReference(String methodOwner, String methodName, List<String> inputs, String output, String whereUsed, @Nullable Integer lineNumber) {
         Objects.requireNonNull(methodOwner);
         Objects.requireNonNull(methodName);
         Objects.requireNonNull(inputs);
@@ -79,11 +83,13 @@ public class MethodReferenceRegistry {
         Objects.requireNonNull(whereUsed);
 
         if (!methodOwnerExclusions.contains(methodOwner)) {
+            String useReference = whereUsed + ":" + (lineNumber != null ? lineNumber : "?");
+
             ReferencedMethod referencedMethod = new ReferencedMethod(methodOwner, methodName, inputs, output);
 
             Collection<String> values = Optional.ofNullable(references.get(methodOwner, referencedMethod))
                     .orElse(new HashSet<>());
-            values.add(whereUsed);
+            values.add(useReference);
 
             references.put(methodOwner, referencedMethod, values);
         }

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/model/MethodUse.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/model/MethodUse.java
@@ -1,0 +1,96 @@
+/*
+ * method-use-analyzer
+ *
+ * Copyright (c) 2020 Synopsys, Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.method.analyzer.core.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Represents a specific instance of a reference to an external method (class and line number)
+ *
+ * @author romeara
+ */
+public class MethodUse {
+
+    private final String qualifiedMethodName;
+
+    private final Integer lineNumber;
+
+    /**
+     * @param className
+     *            The qualified name of the source class and method name using the method
+     * @param lineNumber
+     *            The line number the method use is on, if available
+     */
+    public MethodUse(String className, @Nullable Integer lineNumber) {
+        this.qualifiedMethodName = Objects.requireNonNull(className);
+        this.lineNumber = lineNumber;
+    }
+
+    public String getQualifiedMethodName() {
+        return qualifiedMethodName;
+    }
+
+    public Optional<Integer> getLineNumber() {
+        return Optional.ofNullable(lineNumber);
+    }
+
+    public String toSignature() {
+        return getQualifiedMethodName() + ":" + getLineNumber()
+                .map(Object::toString)
+                .orElse("?");
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getQualifiedMethodName(),
+                getLineNumber());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof MethodUse) {
+            MethodUse compare = (MethodUse) obj;
+
+            result = Objects.equals(compare.getQualifiedMethodName(), getQualifiedMethodName())
+                    && Objects.equals(compare.getLineNumber(), getLineNumber());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("qualifiedMethodName", getQualifiedMethodName())
+                .add("lineNumber", getLineNumber())
+                .toString();
+    }
+
+}

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReferencedMethodUsesJson.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReferencedMethodUsesJson.java
@@ -25,10 +25,12 @@ package com.synopsys.method.analyzer.core.report;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
 import com.google.common.base.MoreObjects;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 
 /**
@@ -46,9 +48,13 @@ public class ReferencedMethodUsesJson {
 
     private final Collection<String> uses;
 
-    public ReferencedMethodUsesJson(String id, ReferencedMethod method, Collection<String> uses) {
+    public ReferencedMethodUsesJson(String id, ReferencedMethod method, Collection<MethodUse> uses) {
+        Objects.requireNonNull(uses);
+
         this.method = new ReferencedMethodJson(id, method.getMethodOwner(), method.getMethodName(), method.getInputs(), method.getOutput());
-        this.uses = Objects.requireNonNull(uses);
+        this.uses = uses.stream()
+                .map(MethodUse::toSignature)
+                .collect(Collectors.toList());
     }
 
     public ReferencedMethodJson getMethod() {
@@ -145,8 +151,8 @@ public class ReferencedMethodUsesJson {
         public boolean equals(@Nullable Object obj) {
             boolean result = false;
 
-            if (obj instanceof ReferencedMethodUsesJson.ReferencedMethodJson) {
-                ReferencedMethodUsesJson.ReferencedMethodJson compare = (ReferencedMethodUsesJson.ReferencedMethodJson) obj;
+            if (obj instanceof ReferencedMethodJson) {
+                ReferencedMethodJson compare = (ReferencedMethodJson) obj;
 
                 result = Objects.equals(compare.getId(), getId())
                         && Objects.equals(compare.getMethodOwner(), getMethodOwner())

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReportGenerator.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/ReportGenerator.java
@@ -49,6 +49,7 @@ import com.google.common.collect.Multimap;
 import com.google.common.hash.HashCode;
 import com.google.common.hash.Hashing;
 import com.google.gson.Gson;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 
 /**
@@ -100,7 +101,7 @@ public class ReportGenerator {
      * @throws IOException
      *             If there is an error writing the report to the file system
      */
-    public Path generateReport(Multimap<ReferencedMethod, String> references, Path outputDirectory, String outputFileName) throws IOException {
+    public Path generateReport(Multimap<ReferencedMethod, MethodUse> references, Path outputDirectory, String outputFileName) throws IOException {
         Objects.requireNonNull(references);
         Objects.requireNonNull(outputDirectory);
         Objects.requireNonNull(outputFileName);
@@ -109,7 +110,7 @@ public class ReportGenerator {
         List<String> uniqueMethodKeys = new LinkedList<>();
         List<ReferencedMethodUsesJson> methodUses = new LinkedList<>();
 
-        for (Entry<ReferencedMethod, Collection<String>> entry : references.asMap().entrySet()) {
+        for (Entry<ReferencedMethod, Collection<MethodUse>> entry : references.asMap().entrySet()) {
             // Generation unique, opaque ID to match method uses against
             String id = generateId(entry.getKey());
 

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/ClassMethodReferenceVisitorTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/ClassMethodReferenceVisitorTest.java
@@ -40,6 +40,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Multimap;
 import com.synopsys.method.analyzer.core.bytecode.ClassMethodReferenceVisitor;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 import com.synopsys.method.analyzer.test.core.TestProperties;
 
@@ -49,7 +50,7 @@ public class ClassMethodReferenceVisitorTest {
 
     private static final String CLASS_FILE_REGEX = ".*\\.class";
 
-    private Multimap<ReferencedMethod, String> result = null;
+    private Multimap<ReferencedMethod, MethodUse> result = null;
 
     @BeforeClass
     public void analyze() throws Exception {
@@ -86,9 +87,9 @@ public class ClassMethodReferenceVisitorTest {
 
         Assert.assertTrue(result.containsKey(objectConstructorReference));
 
-        Collection<String> objectConstructorReferences = result.get(objectConstructorReference);
+        Collection<MethodUse> objectConstructorReferences = result.get(objectConstructorReference);
         Assert.assertEquals(objectConstructorReferences.size(), 1, "Found unexpected number of results: " + objectConstructorReferences);
-        Assert.assertTrue(objectConstructorReferences.contains("com.synopsys.method.analyzer.test.project.BasicTestClass.<init>:28"),
+        Assert.assertTrue(objectConstructorReferences.contains(new MethodUse("com.synopsys.method.analyzer.test.project.BasicTestClass.<init>", 28)),
                 "Unexpected reference: " + objectConstructorReferences);
     }
 
@@ -98,9 +99,9 @@ public class ClassMethodReferenceVisitorTest {
         ReferencedMethod systemPropertyReference = new ReferencedMethod("java.lang.System", "getProperty", Arrays.asList("java.lang.String"),
                 "java.lang.String");
 
-        Collection<String> systemPropertyReferences = result.get(systemPropertyReference);
+        Collection<MethodUse> systemPropertyReferences = result.get(systemPropertyReference);
         Assert.assertEquals(systemPropertyReferences.size(), 1, "Found unexpected number of results: " + systemPropertyReferences);
-        Assert.assertTrue(systemPropertyReferences.contains("com.synopsys.method.analyzer.test.project.BasicTestClass.<init>:30"),
+        Assert.assertTrue(systemPropertyReferences.contains(new MethodUse("com.synopsys.method.analyzer.test.project.BasicTestClass.<init>", 30)),
                 "Unexpected reference: " + systemPropertyReferences);
     }
 
@@ -109,9 +110,9 @@ public class ClassMethodReferenceVisitorTest {
     public void withinMethodReference() throws Exception {
         ReferencedMethod stringFormatReference = new ReferencedMethod("java.lang.String", "format", Arrays.asList("java.lang.String", "java.lang.Object[]"),
                 "java.lang.String");
-        Collection<String> stringFormatReferences = result.get(stringFormatReference);
+        Collection<MethodUse> stringFormatReferences = result.get(stringFormatReference);
         Assert.assertEquals(stringFormatReferences.size(), 1, "Found unexpected number of results: " + stringFormatReferences);
-        Assert.assertTrue(stringFormatReferences.contains("com.synopsys.method.analyzer.test.project.BasicTestClass.getThing:35"),
+        Assert.assertTrue(stringFormatReferences.contains(new MethodUse("com.synopsys.method.analyzer.test.project.BasicTestClass.getThing", 35)),
                 "Unexpected reference: " + stringFormatReferences);
     }
 
@@ -120,14 +121,15 @@ public class ClassMethodReferenceVisitorTest {
     public void withinLambdaReference() throws Exception {
         ReferencedMethod stringToUpperCaseReference = new ReferencedMethod("java.lang.String", "toUpperCase", Collections.emptyList(),
                 "java.lang.String");
-        Collection<String> stringToUpperCaseReferences = result.get(stringToUpperCaseReference);
+        Collection<MethodUse> stringToUpperCaseReferences = result.get(stringToUpperCaseReference);
 
         // This validation is weird, because compiling with Eclipse vs with Gradle resulted in different behavior in
         // terms of the line number associated with the dynamic invocation of the method. This difference is all the way
         // at the bytecode level
         Assert.assertFalse(stringToUpperCaseReferences.isEmpty());
         Assert.assertTrue(
-                stringToUpperCaseReferences.stream().allMatch(s -> s.startsWith("com.synopsys.method.analyzer.test.project.BasicTestClass.getDynamic")),
+                stringToUpperCaseReferences.stream()
+                        .allMatch(s -> s.getQualifiedMethodName().startsWith("com.synopsys.method.analyzer.test.project.BasicTestClass.getDynamic")),
                 "Unexpected reference: " + stringToUpperCaseReferences);
     }
 

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/MethodReferenceRegistryTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/MethodReferenceRegistryTest.java
@@ -36,36 +36,36 @@ public class MethodReferenceRegistryTest {
 
     @Test(expectedExceptions = NullPointerException.class)
     public void registerReferenceNullMethodOwner() throws Exception {
-        new MethodReferenceRegistry().registerReference(null, "methodName", Collections.emptyList(), "output", "whereUsed");
+        new MethodReferenceRegistry().registerReference(null, "methodName", Collections.emptyList(), "output", "whereUsed", 0);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void registerReferenceNullMethodName() throws Exception {
-        new MethodReferenceRegistry().registerReference("methodOwner", null, Collections.emptyList(), "output", "whereUsed");
+        new MethodReferenceRegistry().registerReference("methodOwner", null, Collections.emptyList(), "output", "whereUsed", 0);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void registerReferenceNullInputs() throws Exception {
-        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", null, "output", "whereUsed");
+        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", null, "output", "whereUsed", 0);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void registerReferenceNullOutput() throws Exception {
-        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", Collections.emptyList(), null, "whereUsed");
+        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", Collections.emptyList(), null, "whereUsed", 0);
     }
 
     @Test(expectedExceptions = NullPointerException.class)
     public void registerReferenceNullWhereUsed() throws Exception {
-        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", Collections.emptyList(), "output", null);
+        new MethodReferenceRegistry().registerReference("methodOwner", "methodName", Collections.emptyList(), "output", null, 0);
     }
 
     @Test
-    public void registerReference() throws Exception {
+    public void registerReferenceNullLineNumber() throws Exception {
         ReferencedMethod expectedKey = new ReferencedMethod("methodOwner", "methodName", Collections.emptyList(), "output");
 
         MethodReferenceRegistry methodReferenceRegistry = new MethodReferenceRegistry();
 
-        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed");
+        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", null);
 
         Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
 
@@ -77,7 +77,28 @@ public class MethodReferenceRegistryTest {
         Collection<String> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed"));
+        Assert.assertTrue(whereUsedResult.contains("whereUsed:?"));
+    }
+
+    @Test
+    public void registerReference() throws Exception {
+        ReferencedMethod expectedKey = new ReferencedMethod("methodOwner", "methodName", Collections.emptyList(), "output");
+
+        MethodReferenceRegistry methodReferenceRegistry = new MethodReferenceRegistry();
+
+        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", 1);
+
+        Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
+
+        Assert.assertNotNull(result);
+        Assert.assertEquals(result.keySet().size(), 1);
+
+        Assert.assertTrue(result.containsKey(expectedKey));
+
+        Collection<String> whereUsedResult = result.get(expectedKey);
+        Assert.assertNotNull(whereUsedResult);
+        Assert.assertEquals(whereUsedResult.size(), 1);
+        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -93,8 +114,8 @@ public class MethodReferenceRegistryTest {
         MethodReferenceRegistry methodReferenceRegistry = new MethodReferenceRegistry();
 
         methodReferenceRegistry.registerExclusion(excludedMethodOwner);
-        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed");
-        methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed");
+        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", 1);
+        methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed", 2);
 
         Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
 
@@ -106,7 +127,7 @@ public class MethodReferenceRegistryTest {
         Collection<String> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed"));
+        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
     }
 
     @Test
@@ -116,8 +137,8 @@ public class MethodReferenceRegistryTest {
 
         MethodReferenceRegistry methodReferenceRegistry = new MethodReferenceRegistry();
 
-        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed");
-        methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed");
+        methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", 1);
+        methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed", 2);
         methodReferenceRegistry.registerExclusion(excludedMethodOwner);
 
         Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
@@ -130,7 +151,7 @@ public class MethodReferenceRegistryTest {
         Collection<String> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed"));
+        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
     }
 
 }

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/MethodReferenceRegistryTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/bytecode/MethodReferenceRegistryTest.java
@@ -30,6 +30,7 @@ import org.testng.annotations.Test;
 
 import com.google.common.collect.Multimap;
 import com.synopsys.method.analyzer.core.bytecode.MethodReferenceRegistry;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 
 public class MethodReferenceRegistryTest {
@@ -67,17 +68,17 @@ public class MethodReferenceRegistryTest {
 
         methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", null);
 
-        Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
+        Multimap<ReferencedMethod, MethodUse> result = methodReferenceRegistry.getReferences();
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.keySet().size(), 1);
 
         Assert.assertTrue(result.containsKey(expectedKey));
 
-        Collection<String> whereUsedResult = result.get(expectedKey);
+        Collection<MethodUse> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed:?"));
+        Assert.assertTrue(whereUsedResult.contains(new MethodUse("whereUsed", null)));
     }
 
     @Test
@@ -88,17 +89,17 @@ public class MethodReferenceRegistryTest {
 
         methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", 1);
 
-        Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
+        Multimap<ReferencedMethod, MethodUse> result = methodReferenceRegistry.getReferences();
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.keySet().size(), 1);
 
         Assert.assertTrue(result.containsKey(expectedKey));
 
-        Collection<String> whereUsedResult = result.get(expectedKey);
+        Collection<MethodUse> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
+        Assert.assertTrue(whereUsedResult.contains(new MethodUse("whereUsed", 1)));
     }
 
     @Test(expectedExceptions = NullPointerException.class)
@@ -117,17 +118,17 @@ public class MethodReferenceRegistryTest {
         methodReferenceRegistry.registerReference("methodOwner", "methodName", Collections.emptyList(), "output", "whereUsed", 1);
         methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed", 2);
 
-        Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
+        Multimap<ReferencedMethod, MethodUse> result = methodReferenceRegistry.getReferences();
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.keySet().size(), 1);
 
         Assert.assertTrue(result.containsKey(expectedKey));
 
-        Collection<String> whereUsedResult = result.get(expectedKey);
+        Collection<MethodUse> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
+        Assert.assertTrue(whereUsedResult.contains(new MethodUse("whereUsed", 1)));
     }
 
     @Test
@@ -141,17 +142,17 @@ public class MethodReferenceRegistryTest {
         methodReferenceRegistry.registerReference(excludedMethodOwner, "methodName", Collections.emptyList(), "output", "whereUsed", 2);
         methodReferenceRegistry.registerExclusion(excludedMethodOwner);
 
-        Multimap<ReferencedMethod, String> result = methodReferenceRegistry.getReferences();
+        Multimap<ReferencedMethod, MethodUse> result = methodReferenceRegistry.getReferences();
 
         Assert.assertNotNull(result);
         Assert.assertEquals(result.keySet().size(), 1);
 
         Assert.assertTrue(result.containsKey(expectedKey));
 
-        Collection<String> whereUsedResult = result.get(expectedKey);
+        Collection<MethodUse> whereUsedResult = result.get(expectedKey);
         Assert.assertNotNull(whereUsedResult);
         Assert.assertEquals(whereUsedResult.size(), 1);
-        Assert.assertTrue(whereUsedResult.contains("whereUsed:1"));
+        Assert.assertTrue(whereUsedResult.contains(new MethodUse("whereUsed", 1)));
     }
 
 }

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
@@ -44,6 +44,7 @@ import com.google.common.base.Functions;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
+import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
 import com.synopsys.method.analyzer.core.report.MetaDataReportJson;
 import com.synopsys.method.analyzer.core.report.MethodIdsReportJson;
@@ -67,8 +68,8 @@ public class ReportGeneratorTest {
 
     @Test
     public void simpleReport() throws Exception {
-        Multimap<ReferencedMethod, String> references = HashMultimap.create();
-        references.put(new ReferencedMethod("methodOwner", "methodName", Collections.singletonList("input"), "output"), "use");
+        Multimap<ReferencedMethod, MethodUse> references = HashMultimap.create();
+        references.put(new ReferencedMethod("methodOwner", "methodName", Collections.singletonList("input"), "output"), new MethodUse("use", 1));
 
         Path result = reportGenerator.generateReport(references, testReportDirectory, "simpleReport");
 
@@ -124,15 +125,16 @@ public class ReportGeneratorTest {
         Assert.assertEquals(resultJson.getMethod().getOutput(), "output");
         Assert.assertEquals(resultJson.getMethod().getInputs(), Collections.singletonList("input"));
         Assert.assertEquals(resultJson.getUses().size(), 1);
-        Assert.assertTrue(resultJson.getUses().contains("use"));
+        Assert.assertTrue(resultJson.getUses().contains("use:1"));
     }
 
     @Test
     public void partitionedReport() throws Exception {
-        Multimap<ReferencedMethod, String> references = HashMultimap.create();
+        Multimap<ReferencedMethod, MethodUse> references = HashMultimap.create();
 
         for (int i = 0; i < 2000; i++) {
-            references.put(new ReferencedMethod("methodOwner" + i, "methodName" + i, Collections.singletonList("input" + i), "output" + i), "use" + i);
+            references.put(new ReferencedMethod("methodOwner" + i, "methodName" + i, Collections.singletonList("input" + i), "output" + i),
+                    new MethodUse("use" + i, i));
         }
 
         Path result = reportGenerator.generateReport(references, testReportDirectory, "simpleReport");


### PR DESCRIPTION
Pass around where-used data as separate user/line-number values instead of a separate string. This will allow (NOT yet implemented) the reporting of these values separately within the JSON reports.