### PR TITLE
GH-28 Update handling of files which failed to parse

### DIFF
--- a/CHANGE_LOG.md
+++ b/CHANGE_LOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Changed
+- (GH-28) Record files which failed to parse in a report, instead of failing the entire analysis
 
 ## [0.1.7]
 ### Changed

--- a/docs/REPORT_FORMAT.md
+++ b/docs/REPORT_FORMAT.md
@@ -54,6 +54,17 @@ The "method uses" report(s) are within the `referenced-method-uses` directory of
   - The qualified class and method name the reference is located in
 - methodUses[].uses[].lineNumber
   - Optional - the line number the reference is made on within the source file
+  
+## Broken Files Report
+
+The "broken files" report(s) are within the "broken-files" directory of the expanded report file. Each of these files is a JSON file, containing several elements:
+
+- brokenFiles[]
+  - Array of all broken files described by this report
+- brokenFiles[].path
+  - Path of the file which failed to parse
+- brokenFiles[].error
+  - Optional. Short text string describing the error which prevented parsing
 
 ## ID Generation
 

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/BrokenFileJson.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/BrokenFileJson.java
@@ -1,0 +1,88 @@
+/*
+ * method-use-analyzer
+ *
+ * Copyright (C) 2022 Synopsys Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.method.analyzer.core.report;
+
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Represents JSON data for a file which failed to parse within an analyzed project
+ *
+ * <p>
+ * Fields within correspond to a defined file format - alterations require evaluation for backwards compatibility and
+ * required version control
+ *
+ * @author romeara
+ */
+public class BrokenFileJson {
+
+    private final String path;
+
+    private final String error;
+
+    public BrokenFileJson(String path, @Nullable String error) {
+        this.path = Objects.requireNonNull(path);
+        this.error = error;
+    }
+
+    public String getPath() {
+        return path;
+    }
+
+    @Nullable
+    public String getError() {
+        return error;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getPath(),
+                getError());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof BrokenFileJson) {
+            BrokenFileJson compare = (BrokenFileJson) obj;
+
+            result = Objects.equals(compare.getPath(), getPath())
+                    && Objects.equals(compare.getError(), getError());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("path", getPath())
+                .add("error", getError())
+                .toString();
+    }
+
+}

--- a/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/BrokenFilesReportJson.java
+++ b/method-analyzer-core/src/main/java/com/synopsys/method/analyzer/core/report/BrokenFilesReportJson.java
@@ -1,0 +1,78 @@
+/*
+ * method-use-analyzer
+ *
+ * Copyright (C) 2022 Synopsys Inc.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements. See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership. The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package com.synopsys.method.analyzer.core.report;
+
+import java.util.List;
+import java.util.Objects;
+
+import javax.annotation.Nullable;
+
+import com.google.common.base.MoreObjects;
+
+/**
+ * Represents full JSON contents for a report on broken files which failed to parse within an analyzed project
+ *
+ * <p>
+ * Fields within correspond to a defined file format - alterations require evaluation for backwards compatibility and
+ * required version control
+ *
+ * @author romeara
+ */
+public final class BrokenFilesReportJson {
+
+    private final List<BrokenFileJson> brokenFiles;
+
+    public BrokenFilesReportJson(List<BrokenFileJson> brokenFiles) {
+        this.brokenFiles = Objects.requireNonNull(brokenFiles);
+    }
+
+    public List<BrokenFileJson> getBrokenFiles() {
+        return brokenFiles;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getBrokenFiles());
+    }
+
+    @Override
+    public boolean equals(@Nullable Object obj) {
+        boolean result = false;
+
+        if (obj instanceof BrokenFilesReportJson) {
+            BrokenFilesReportJson compare = (BrokenFilesReportJson) obj;
+
+            result = Objects.equals(compare.getBrokenFiles(), getBrokenFiles());
+        }
+
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return MoreObjects.toStringHelper(getClass()).omitNullValues()
+                .add("brokenFiles", getBrokenFiles())
+                .toString();
+    }
+
+}

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
@@ -28,6 +28,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -159,7 +160,7 @@ public class ReportGeneratorTest {
         references.put(new ReferencedMethod("methodOwner2", "methodName2", Collections.singletonList("input2"), "output2"), new MethodUse("use", null));
 
         Map<Path, String> brokenFiles = new HashMap<>();
-        brokenFiles.put(Path.of("broken/BFile.class"), "Caused by TestException at MethodUseAnalyzer.java:123");
+        brokenFiles.put(Paths.get("broken/BFile.class"), "Caused by TestException at MethodUseAnalyzer.java:123");
 
         Path result = reportGenerator.generateReport(references, brokenFiles, testReportDirectory, "simpleReport");
 
@@ -259,7 +260,7 @@ public class ReportGeneratorTest {
         for (int i = 0; i < 2000; i++) {
             references.put(new ReferencedMethod("methodOwner" + i, "methodName" + i, Collections.singletonList("input" + i), "output" + i),
                     new MethodUse("use" + i, i));
-            brokenFiles.put(Path.of("broken/BFile" + i + ".class"), "Caused by TestException at MethodUseAnalyzer.java:123 " + i);
+            brokenFiles.put(Paths.get("broken/BFile" + i + ".class"), "Caused by TestException at MethodUseAnalyzer.java:123 " + i);
         }
 
         Path result = reportGenerator.generateReport(references, brokenFiles, testReportDirectory, "simpleReport");

--- a/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
+++ b/method-analyzer-core/src/test/java/com/synopsys/method/analyzer/test/core/report/ReportGeneratorTest.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -46,6 +47,8 @@ import com.google.common.collect.Multimap;
 import com.google.gson.Gson;
 import com.synopsys.method.analyzer.core.model.MethodUse;
 import com.synopsys.method.analyzer.core.model.ReferencedMethod;
+import com.synopsys.method.analyzer.core.report.BrokenFileJson;
+import com.synopsys.method.analyzer.core.report.BrokenFilesReportJson;
 import com.synopsys.method.analyzer.core.report.MetaDataReportJson;
 import com.synopsys.method.analyzer.core.report.MethodIdJson;
 import com.synopsys.method.analyzer.core.report.MethodIdsReportJson;
@@ -69,7 +72,8 @@ public class ReportGeneratorTest {
     }
 
     @Test
-    public void simpleReport() throws Exception {
+    @SuppressWarnings("deprecation")
+    public void simpleReportLegacyNoBrokenFiles() throws Exception {
         Multimap<ReferencedMethod, MethodUse> references = HashMultimap.create();
         references.put(new ReferencedMethod("methodOwner", "methodName", Collections.singletonList("input"), "output"), new MethodUse("use", 1));
         references.put(new ReferencedMethod("methodOwner2", "methodName2", Collections.singletonList("input2"), "output2"), new MethodUse("use", null));
@@ -149,15 +153,116 @@ public class ReportGeneratorTest {
     }
 
     @Test
+    public void simpleReport() throws Exception {
+        Multimap<ReferencedMethod, MethodUse> references = HashMultimap.create();
+        references.put(new ReferencedMethod("methodOwner", "methodName", Collections.singletonList("input"), "output"), new MethodUse("use", 1));
+        references.put(new ReferencedMethod("methodOwner2", "methodName2", Collections.singletonList("input2"), "output2"), new MethodUse("use", null));
+
+        Map<Path, String> brokenFiles = new HashMap<>();
+        brokenFiles.put(Path.of("broken/BFile.class"), "Caused by TestException at MethodUseAnalyzer.java:123");
+
+        Path result = reportGenerator.generateReport(references, brokenFiles, testReportDirectory, "simpleReport");
+
+        Assert.assertNotNull(result);
+        Assert.assertTrue(Files.exists(result));
+
+        Path resultExpandedDirectory = unzip(result);
+
+        Path expectedMetaData = resultExpandedDirectory.resolve("metaData.json");
+        Path expectedReferencedMethod = resultExpandedDirectory.resolve("referenced-methods").resolve("referenced-methods-0.json");
+        Path expectedReferencedMethodUses = resultExpandedDirectory.resolve("referenced-method-uses").resolve("referenced-method-uses-0.json");
+        Path expectedBrokenFiles = resultExpandedDirectory.resolve("broken-files").resolve("broken-files-0.json");
+
+        Assert.assertTrue(Files.exists(expectedReferencedMethod));
+        Assert.assertTrue(Files.exists(expectedReferencedMethodUses));
+        Assert.assertTrue(Files.exists(expectedBrokenFiles));
+
+        MetaDataReportJson metaDataReport = null;
+        MethodIdsReportJson methodIdsReport = null;
+        MethodReferencesReportJson methodReferencesReport = null;
+        BrokenFilesReportJson brokenFilesReport = null;
+
+        try (BufferedReader reader = Files.newBufferedReader(expectedMetaData)) {
+            metaDataReport = GSON.fromJson(reader, MetaDataReportJson.class);
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(expectedReferencedMethod)) {
+            methodIdsReport = GSON.fromJson(reader, MethodIdsReportJson.class);
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(expectedReferencedMethodUses)) {
+            methodReferencesReport = GSON.fromJson(reader, MethodReferencesReportJson.class);
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(expectedBrokenFiles)) {
+            brokenFilesReport = GSON.fromJson(reader, BrokenFilesReportJson.class);
+        }
+
+        Assert.assertNotNull(metaDataReport);
+        Assert.assertNotNull(methodIdsReport);
+        Assert.assertNotNull(methodReferencesReport);
+        Assert.assertNotNull(brokenFilesReport);
+
+        Assert.assertEquals(metaDataReport.getHostName(), "hostName");
+        Assert.assertEquals(metaDataReport.getAnalyzedDirectory(), "analyzedDirectory");
+        Assert.assertEquals(metaDataReport.getCodeLocationName(), "codeLocationName");
+
+        Map<String, ReferencedMethodUsesJson> usesById = methodReferencesReport.getMethodUses().stream()
+                .collect(Collectors.toMap(use -> use.getMethod().getId(), Functions.identity()));
+
+        Set<String> signatureIds = methodIdsReport.getMethodIds().stream()
+                .map(MethodIdJson::getSignature)
+                .collect(Collectors.toSet());
+
+        Assert.assertEquals(signatureIds.size(), usesById.size());
+        Assert.assertTrue(signatureIds.containsAll(usesById.keySet()));
+
+        ReferencedMethodUsesJson resultJson = usesById.get("n0VJzGLYjELWet+V5A3IxQgkG/kQRR3P0OTmEpiScZs=");
+
+        Assert.assertNotNull(resultJson, "Expected reference ID not found, check that ID generation logic in ReportGenerator was not changed unintentionally.");
+        Assert.assertEquals(resultJson.getMethod().getId(), "n0VJzGLYjELWet+V5A3IxQgkG/kQRR3P0OTmEpiScZs=",
+                "Referenced Method ID was unexpected value, check that ID generation logic in ReportGenerator was not changed unintentionally.");
+        Assert.assertEquals(resultJson.getMethod().getMethodName(), "methodName");
+        Assert.assertEquals(resultJson.getMethod().getMethodOwner(), "methodOwner");
+        Assert.assertEquals(resultJson.getMethod().getOutput(), "output");
+        Assert.assertEquals(resultJson.getMethod().getInputs(), Collections.singletonList("input"));
+        Assert.assertEquals(resultJson.getUses().size(), 1);
+        Assert.assertTrue(resultJson.getUses().contains(new MethodUseJson("use", 1)));
+
+        ReferencedMethodUsesJson resultJsonNullLineNumber = usesById.get("lnTAAs55NfVEpFXFtKvJ5KmvK6Z6En4jHzP2Xp3PL7g=");
+
+        Assert.assertNotNull(resultJsonNullLineNumber,
+                "Expected reference ID not found, check that ID generation logic in ReportGenerator was not changed unintentionally.");
+        Assert.assertEquals(resultJsonNullLineNumber.getMethod().getId(), "lnTAAs55NfVEpFXFtKvJ5KmvK6Z6En4jHzP2Xp3PL7g=",
+                "Referenced Method ID was unexpected value, check that ID generation logic in ReportGenerator was not changed unintentionally.");
+        Assert.assertEquals(resultJsonNullLineNumber.getMethod().getMethodName(), "methodName2");
+        Assert.assertEquals(resultJsonNullLineNumber.getMethod().getMethodOwner(), "methodOwner2");
+        Assert.assertEquals(resultJsonNullLineNumber.getMethod().getOutput(), "output2");
+        Assert.assertEquals(resultJsonNullLineNumber.getMethod().getInputs(), Collections.singletonList("input2"));
+        Assert.assertEquals(resultJsonNullLineNumber.getUses().size(), 1);
+        Assert.assertTrue(resultJsonNullLineNumber.getUses().contains(new MethodUseJson("use", null)));
+
+        Assert.assertNotNull(brokenFilesReport.getBrokenFiles());
+        Assert.assertEquals(brokenFilesReport.getBrokenFiles().size(), 1);
+
+        BrokenFileJson brokenFileJson = brokenFilesReport.getBrokenFiles().get(0);
+        Assert.assertNotNull(brokenFileJson);
+        Assert.assertEquals(brokenFileJson.getPath(), "broken/BFile.class");
+        Assert.assertEquals(brokenFileJson.getError(), "Caused by TestException at MethodUseAnalyzer.java:123");
+    }
+
+    @Test
     public void partitionedReport() throws Exception {
         Multimap<ReferencedMethod, MethodUse> references = HashMultimap.create();
+        Map<Path, String> brokenFiles = new HashMap<>();
 
         for (int i = 0; i < 2000; i++) {
             references.put(new ReferencedMethod("methodOwner" + i, "methodName" + i, Collections.singletonList("input" + i), "output" + i),
                     new MethodUse("use" + i, i));
+            brokenFiles.put(Path.of("broken/BFile" + i + ".class"), "Caused by TestException at MethodUseAnalyzer.java:123 " + i);
         }
 
-        Path result = reportGenerator.generateReport(references, testReportDirectory, "simpleReport");
+        Path result = reportGenerator.generateReport(references, brokenFiles, testReportDirectory, "simpleReport");
 
         Assert.assertNotNull(result);
         Assert.assertTrue(Files.exists(result));
@@ -167,19 +272,25 @@ public class ReportGeneratorTest {
         Path expectedMetaData = resultExpandedDirectory.resolve("metaData.json");
         Path expectedReferencedMethod1 = resultExpandedDirectory.resolve("referenced-methods").resolve("referenced-methods-0.json");
         Path expectedReferencedMethodUses1 = resultExpandedDirectory.resolve("referenced-method-uses").resolve("referenced-method-uses-0.json");
+        Path expectedBrokenFiles1 = resultExpandedDirectory.resolve("broken-files").resolve("broken-files-0.json");
         Path expectedReferencedMethod2 = resultExpandedDirectory.resolve("referenced-methods").resolve("referenced-methods-1.json");
         Path expectedReferencedMethodUses2 = resultExpandedDirectory.resolve("referenced-method-uses").resolve("referenced-method-uses-1.json");
+        Path expectedBrokenFiles2 = resultExpandedDirectory.resolve("broken-files").resolve("broken-files-1.json");
 
         Assert.assertTrue(Files.exists(expectedReferencedMethod1), "Expected " + expectedReferencedMethod1 + " to exist");
         Assert.assertTrue(Files.exists(expectedReferencedMethodUses1), "Expected " + expectedReferencedMethodUses1 + " to exist");
+        Assert.assertTrue(Files.exists(expectedBrokenFiles1), "Expected " + expectedBrokenFiles1 + " to exist");
         Assert.assertTrue(Files.exists(expectedReferencedMethod2), "Expected " + expectedReferencedMethod2 + " to exist");
         Assert.assertTrue(Files.exists(expectedReferencedMethodUses2), "Expected " + expectedReferencedMethodUses2 + " to exist");
+        Assert.assertTrue(Files.exists(expectedBrokenFiles2), "Expected " + expectedBrokenFiles2 + " to exist");
 
         MetaDataReportJson metaDataReport = null;
         MethodIdsReportJson methodIdsReport1 = null;
         MethodReferencesReportJson methodReferencesReport1 = null;
+        BrokenFilesReportJson brokenFilesReport1 = null;
         MethodIdsReportJson methodIdsReport2 = null;
         MethodReferencesReportJson methodReferencesReport2 = null;
+        BrokenFilesReportJson brokenFilesReport2 = null;
 
         try (BufferedReader reader = Files.newBufferedReader(expectedMetaData)) {
             metaDataReport = GSON.fromJson(reader, MetaDataReportJson.class);
@@ -201,11 +312,21 @@ public class ReportGeneratorTest {
             methodReferencesReport2 = GSON.fromJson(reader, MethodReferencesReportJson.class);
         }
 
+        try (BufferedReader reader = Files.newBufferedReader(expectedBrokenFiles1)) {
+            brokenFilesReport1 = GSON.fromJson(reader, BrokenFilesReportJson.class);
+        }
+
+        try (BufferedReader reader = Files.newBufferedReader(expectedBrokenFiles2)) {
+            brokenFilesReport2 = GSON.fromJson(reader, BrokenFilesReportJson.class);
+        }
+
         Assert.assertNotNull(metaDataReport);
         Assert.assertNotNull(methodIdsReport1);
         Assert.assertNotNull(methodReferencesReport1);
+        Assert.assertNotNull(brokenFilesReport1);
         Assert.assertNotNull(methodIdsReport2);
         Assert.assertNotNull(methodReferencesReport2);
+        Assert.assertNotNull(brokenFilesReport2);
 
         Assert.assertEquals(metaDataReport.getHostName(), "hostName");
         Assert.assertEquals(metaDataReport.getAnalyzedDirectory(), "analyzedDirectory");
@@ -214,6 +335,8 @@ public class ReportGeneratorTest {
         // Check partitioning numbers are correct
         Assert.assertEquals(methodIdsReport1.getMethodIds().size(), 1000);
         Assert.assertEquals(methodIdsReport2.getMethodIds().size(), 1000);
+        Assert.assertEquals(brokenFilesReport1.getBrokenFiles().size(), 1000);
+        Assert.assertEquals(brokenFilesReport2.getBrokenFiles().size(), 1000);
 
         Set<String> allIds = Stream.concat(methodIdsReport1.getMethodIds().stream(), methodIdsReport2.getMethodIds().stream())
                 .map(MethodIdJson::getSignature)


### PR DESCRIPTION
Prevent analysis failure when a file fails to parse, instead recording
the failure in a report before moving on to the next file